### PR TITLE
Fix uint8 overflow issue in fold 

### DIFF
--- a/RibosoftAlgo/src/fold.cpp
+++ b/RibosoftAlgo/src/fold.cpp
@@ -1,7 +1,6 @@
 #include "dll.h"
 
 #include <cstdlib>
-#include <cstring>
 
 #include <ViennaRNA/data_structures.h>
 #include <ViennaRNA/subopt.h>

--- a/RibosoftAlgo/src/functions.h
+++ b/RibosoftAlgo/src/functions.h
@@ -4,6 +4,7 @@
 #include "error.h"
 
 #include <cstdint>
+#include <cstring>
 
 RIBOSOFT_NAMESPACE_START
 


### PR DESCRIPTION
Caused guaranteed crash with runaway memory (infinite loop with `new`) when solution_size is bigger than 255, the max value for idx_t.