### PR TITLE
Fix Kestrel certificate configuration to properly handle environment …

### DIFF
--- a/Ribosoft/Program.cs
+++ b/Ribosoft/Program.cs
@@ -7,6 +7,7 @@ using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Mvc.Authorization;
 using Microsoft.AspNetCore.Mvc.Razor;
 using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Server.Kestrel.Core;
 using NLog;
 using NLog.Web;
 using Ribosoft.Configuration;
@@ -170,6 +171,9 @@ public class Program
         {
             options.Queues = new[] { "default", "blast", "downloads", "downloads-high", "downloads-low" };
         });
+
+        // Configure Kestrel for HTTPS certificates
+        services.Configure<KestrelServerOptions>(configuration.GetSection("Kestrel"));
     }
     
     private static void ConfigurePipeline(WebApplication app)


### PR DESCRIPTION
…variables

- Added KestrelServerOptions configuration binding to services
- Added Microsoft.AspNetCore.Server.Kestrel.Core using statement
- Enables proper environment variable support for certificates:
  - ASPNETCORE_Kestrel__Certificates__Default__Path
  - ASPNETCORE_Kestrel__Certificates__Default__Password
  - ASPNETCORE_Kestrel__Endpoints__Https__Certificate__Path
  - ASPNETCORE_Kestrel__Endpoints__Https__Certificate__Password

This fixes the issue where Kestrel was not picking up certificate environment variables for HTTPS configuration.